### PR TITLE
Header tweaks

### DIFF
--- a/header.php
+++ b/header.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * The header for our theme.
+ *
+ * This is the template that displays all of the <head> section and everything up until <div id="content">
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package MIB_Foundation
+ */
+
+?><!DOCTYPE html>
+<html <?php language_attributes(); ?> itemscope itemtype="http://schema.org/WebPage">
+<head>
+<meta charset="<?php bloginfo( 'charset' ); ?>">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="profile" href="http://gmpg.org/xfn/11">
+<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
+
+<?php wp_head(); ?>
+</head>
+
+<body <?php body_class(); ?>>
+<div id="page" class="site">
+	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'ixion' ); ?></a>
+
+	<header id="masthead" class="site-header" role="banner">
+		<div class="branding-container">
+			<?php get_template_part( 'components/header/site', 'branding' ); ?>
+			<?php get_template_part( 'components/navigation/navigation', 'top' ); ?>
+		</div>
+
+	</header>
+
+	<?php if ( is_front_page() ) : ?>
+		<div class="front-page-wrapper">
+			<div class="header-overlay">
+				<?php if ( get_header_image() ) : ?>
+					<img src="<?php header_image(); ?>" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="">
+				<?php endif; ?>
+				<div class="site-description-wrapper">
+					<?php $description = get_bloginfo( 'description', 'display' );
+					if ( $description || is_customize_preview() ) : ?>
+						<p class="site-description"><?php echo $description; /* WPCS: xss ok. */ ?></p>
+					<?php endif; ?>
+
+					<?php
+					$button = get_theme_mod( 'ixion_button_text', '' );
+
+					if ( '' !== $button || is_customize_preview() ) : ?>
+						<a href="<?php echo esc_url( get_theme_mod( 'ixion_button_link', '' ) ); ?>" class="button callout-button"><?php echo esc_html( $button ); ?></a>
+					<?php endif; ?>
+				</div><!-- .site-description-wrapper -->
+			</div><!-- .header-overlay -->
+			<?php get_template_part( 'components/features/featured-content/display', 'featured' ); ?>
+		</div><!-- .front-page-wrapper -->
+	<?php endif; // End is_front_page() check ?>
+
+	<div id="content" class="site-content">

--- a/style.css
+++ b/style.css
@@ -12,90 +12,94 @@
     Update URI:   false
 */
 
-
 /* Variables
 --------------------------------------------- */
 :root {
     --white: #fafafa;
     --black: #000000;
-    --cream: #F2F2ED;
+    --cream: #f2f2ed;
     --slate: #212121;
-    --maroon: #57181F;
+    --maroon: #57181f;
+}
 
-  }
+/* Typography
+--------------------------------------------- */
+body {
+    font-family: "Barlow", sans-serif;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-family: "Merriweather", serif;
+    font-weight: bold;
+    clear: both;
+    margin: 0.8em 0;
+}
 
 /* Header
 --------------------------------------------- */
 .site-branding {
-  display: flex;
-  flex-direction: column;
+    display: flex;
+    flex-direction: column;
 
     .site-title {
-      font-size: clamp(1rem, 0.59vi + 1.13rem, 1.67rem);
-      width: clamp(50%, 50vw, 40%);
+        font-size: clamp(1rem, 0.59vi + 1.13rem, 1.67rem);
+        width: clamp(50%, 50vw, 40%);
     }
 }
-
-
 
 /* Footer
 --------------------------------------------- */
 
 #colophon {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  background-color: var(--slate);
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--slate);
 }
 
 .footer-img {
-  margin: 0 auto;
-  padding-top: 3rem;
-  
+    margin: 0 auto;
+    padding-top: 3rem;
+
     img.custom-logo {
-      filter: invert();
+        filter: invert();
     }
 }
 
 .footer-links {
-  padding: 2rem 0;
+    padding: 2rem 0;
 }
 
 .footer-navigation ul > li > a {
-	color: var(--white);
-	font-family: "Archivo Narrow", sans-serif;
-	text-transform: uppercase;
+    color: var(--white);
+    font-family: "Archivo Narrow", sans-serif;
+    text-transform: uppercase;
 }
-
 
 #menu-footer {
-  display: flex;
-  justify-content: center;
-  gap: 4rem;
-  list-style: none;
-  margin: 0;
-  padding-right: 1.5rem;
+    display: flex;
+    justify-content: center;
+    gap: 4rem;
+    list-style: none;
+    margin: 0;
+    padding-right: 1.5rem;
 }
-
-
 
 /* Homepage
 --------------------------------------------- */
 /* hero section */
 
-
 /* about section */
-
 
 /* contact section */
 
-
-
 /* Services Page
 --------------------------------------------- */
-
-
-
 
 /* About Page
 --------------------------------------------- */

--- a/style.css
+++ b/style.css
@@ -26,7 +26,15 @@
 
 /* Header
 --------------------------------------------- */
+.site-branding {
+  display: flex;
+  flex-direction: column;
 
+    .site-title {
+      font-size: 2rem;
+      width: 40%;
+    }
+}
 
 
 

--- a/style.css
+++ b/style.css
@@ -12,6 +12,12 @@
     Update URI:   false
 */
 
+/* Smooth Scroll */
+
+html {
+  scroll-behavior: smooth;
+}
+
 /* Variables
 --------------------------------------------- */
 :root {
@@ -95,6 +101,19 @@ h6 {
 /* hero section */
 
 /* about section */
+
+
+#advisor-list {
+  display: flex;
+  width: 50%;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  align-items: center;
+  margin: 0;
+  list-style-type: disc;
+}
+
+
 
 /* contact section */
 

--- a/style.css
+++ b/style.css
@@ -31,8 +31,8 @@
   flex-direction: column;
 
     .site-title {
-      font-size: 2rem;
-      width: 40%;
+      font-size: clamp(1rem, 0.59vi + 1.13rem, 1.67rem);
+      width: clamp(50%, 50vw, 40%);
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /*
     Theme Name:   MIB Foundation Theme
-    Theme URI:    https://wordpress.org/themes/ixion/
+    Theme URI:    
     Author:       Kaleb Link/ Matt Garvey/ Gabbie Bade
     Author URI:   https://kaleblink.com
     Description:  child to the Ixion theme
@@ -16,6 +16,12 @@
 
 html {
   scroll-behavior: smooth;
+}
+
+/* Stupid ixion main-content right hand margin remove */
+
+.site-main {
+  margin: 0;
 }
 
 /* Variables
@@ -54,7 +60,7 @@ h6 {
 
     .site-title {
         font-size: clamp(1rem, 0.59vi + 1.13rem, 1.67rem);
-        width: clamp(50%, 50vw, 40%);
+        width: clamp(30%, 50vw, 60%);
     }
 }
 
@@ -100,18 +106,41 @@ h6 {
 --------------------------------------------- */
 /* hero section */
 
+
+
+
+/* Musical Advantage */
+
+#musical-advantage {
+  width: 100%;
+  background-color: var(--cream);
+
+    h3, p {
+      color: var(--maroon);
+    }
+}
+
+
 /* about section */
 
 
+/* List of Board Members/Advisors */
+
 #advisor-list {
+  margin: 0 auto;
   display: flex;
   width: 50%;
   flex-wrap: wrap;
-  justify-content: space-around;
   align-items: center;
   margin: 0;
   list-style-type: disc;
+
+    li#list-item {
+      width: 10rem;
+    }
 }
+
+
 
 
 
@@ -122,3 +151,9 @@ h6 {
 
 /* About Page
 --------------------------------------------- */
+
+
+
+
+
+


### PR DESCRIPTION
made header template for child theme and removed the random search bar from up top

made header flex-column to display site title below logo like in mockup

added clamps to site title size, as well as how much it expands when resized

added smooth scroll to styles.css + fonts

removed weird 30% margin right on site-main only class(only thing I can think of is they added it incase there was a sidebar)